### PR TITLE
Feat: 로비 채팅 글자 수 제한, 도배 방지, 엔터키로 채팅 인풋 활성화

### DIFF
--- a/frontend/src/components/features/MultiGameLobbyComponent/LobbyChatting/LobbyChatting.tsx
+++ b/frontend/src/components/features/MultiGameLobbyComponent/LobbyChatting/LobbyChatting.tsx
@@ -40,6 +40,23 @@ export const LobbyChatting = (props: OwnProps) => {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const [chatCount, setChatCount] = useState(0);
   const [chatDisabled, setChatDisabled] = useState(false); // 도배 방지를 위한 상태 변수
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleKeyPress = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && inputRef.current && !chatDisabled) {
+        inputRef.current.focus(); // 엔터키가 눌렸을 때 입력 필드에 포커스
+      }
+    };
+
+    // 키보드 이벤트 리스너 등록
+    window.addEventListener('keydown', handleKeyPress);
+
+    // 컴포넌트 언마운트 시 이벤트 리스너 제거
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [chatDisabled]); // 의존성 배열에 chatDisabled 추가
 
   const sendMessage = () => {
     const headers: { [key: string]: string } = {};
@@ -89,6 +106,7 @@ export const LobbyChatting = (props: OwnProps) => {
       <ChattingInputWrapper>
         <StyledInput
           type="text"
+          ref={inputRef}
           placeholder={
             chatDisabled
               ? '잠시 후 다시 시도해주세요'


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
- close #11, #19 
<br>
<br>

### 3️⃣ 변경 사항
- 로비 채팅 글자 수를 100자로 제한하였습니다.
- 5회 연속 채팅 시 3초간의 유예를 두었습니다.
- 엔터키로 채팅인풋을 활성화 할 수 있는 기능을 추가하였습니다
<br>
<br>

### 4️⃣ 테스트 결과
-
